### PR TITLE
Fix Token already used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [3.0.4](https://github.com/conekta/conekta-woocommerce/releases/tag/v3.0.4) - 2018-04-11
+## Fix 
+- Fix for error token already used
+
 ## [3.0.3](https://github.com/conekta/conekta-woocommerce/releases/tag/v3.0.3) - 2018-01-10
 ## Changed
 - Update PHP Lib compatible with PHP 7+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Conekta Woocommerce v.3.0.3
+Conekta Woocommerce v.3.0.4
 ================================
 
 WooCommerce Payment Gateway for Conekta.io

--- a/conekta_card_gateway.php
+++ b/conekta_card_gateway.php
@@ -307,6 +307,7 @@ class WC_Conekta_Card_Gateway extends WC_Conekta_Plugin
         else
         {
             $this->ckpg_mark_as_failed_payment();
+            WC()->session->reload_checkout = true;
         }
     }
 

--- a/conekta_checkout.php
+++ b/conekta_checkout.php
@@ -4,7 +4,7 @@
 Plugin Name: Conekta Payment Gateway
 Plugin URI: https://wordpress.org/plugins/conekta-woocommerce/
 Description: Payment Gateway through Conekta.io for Woocommerce for both credit and debit cards as well as cash payments in OXXO and monthly installments for Mexican credit cards.
-Version: 3.0.3
+Version: 3.0.4
 Author: Conekta.io
 Author URI: https://www.conekta.io
 License: GNU General Public License v3.0

--- a/conekta_plugin.php
+++ b/conekta_plugin.php
@@ -13,7 +13,7 @@ if (!class_exists('Conekta'))
 
 class WC_Conekta_Plugin extends WC_Payment_Gateway
 {
-	public $version  = "3.0.3";
+	public $version  = "3.0.4";
 	public $name = "WooCommerce 2";
 	public $description = "Payment Gateway through Conekta.io for Woocommerce for both credit and debit cards as well as cash payments in OXXO and monthly installments for Mexican credit cards.";
 	public $plugin_name = "Conekta Payment Gateway for Woocommerce";

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: cristinarandall, eduardoconekta, jovalo
 Tags: free, oxxo, conekta, mexico, payment gateway
 Requires at least: 3.5.2
 Tested up to: 4.8.1
-Stable tag: 3.0.3
+Stable tag: 3.0.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
**Why is this change neccesary?** 
In order to have a better user experience buying on every woocommerce site.
Before, when clients clicks  "place order" button and a error was showed the order data was persistent, so when they try again to re submit their order all data are the same as before even the token id.
Solves a critical bug 

**How does it address the issue?**
* Refresh the page once the error is showed 

issue
https://github.com/conekta/issues/issues/2750

### Testing same error calls (all generate new tokenization)

* ![captura de pantalla 2018-04-10 a la s 18 03 38](https://user-images.githubusercontent.com/26972091/38588067-87f82db0-3ce9-11e8-916b-0db9a0eb361e.png)

### How looks before the fix

* ![captura de pantalla 2018-04-10 a la s 18 04 52](https://user-images.githubusercontent.com/26972091/38588107-b2ff7dec-3ce9-11e8-8a44-95ed98873a68.png)

