### PR TITLE
Fix, method return value context

### DIFF
--- a/conekta_gateway_helper.php
+++ b/conekta_gateway_helper.php
@@ -282,12 +282,12 @@ function ckpg_get_request_data($order)
             'customer_info'        => $customer_info,
             'shipping_lines'       => $shipping_lines
         );
-
-        if (!empty($order->get_shipping_address_1())) {
+        $address_1 = $order->get_shipping_address_1();
+        if (!empty($address1)) {
             $data = array_merge($data, array('shipping_contact' => $shipping_contact));
         }
-
-        if (!empty($order->get_customer_note())) {
+        $customer_note = $order->get_customer_note();
+        if (!empty($customer_note)) {
             $data = array_merge($data, array('customer_message' => $order->get_customer_note()));
         }
 


### PR DESCRIPTION
in order to solve https://github.com/conekta/conekta-woocommerce/issues/91 as seen in https://stackoverflow.com/questions/1075534/cant-use-method-return-value-in-write-context this error comes up when `empty` function try to access  before 5.5 didn't support references to temporary values returned from functions. 