### PR TITLE
feature: Integrate styles to WooCommerce iFrame plugin.

### DIFF
--- a/assets/js/tokenize.js
+++ b/assets/js/tokenize.js
@@ -1,41 +1,133 @@
-jQuery(document).ready(function($) {
-	Conekta.setPublishableKey(wc_conekta_params.public_key);
+jQuery(document).ready(function ($) {
+  var checkout;
+  var $form = $("form.checkout,form#order_review");
+  var $paymentErrors = $form.find('.payment_method_conektacard .payment-errors');
+  var showError = function (message) {
+    $paymentErrors.text(message);
+    $form.unblock();
+  }
 
-	var $form = $('form.checkout,form#order_review');
+  $paymentErrors.html('');
 
-	var conektaErrorResponseHandler = function(response) {
-		$form.find('.payment-errors').text(response.message_to_purchaser);
-		$form.unblock();
-	};
+  $("body").on("click", "form#order_review input:submit", function () {
+    if ($("input[name=payment_method]:checked").val() != "conektacard") {
+      return true;
+    }
+    return false;
+  });
 
-	var conektaSuccessResponseHandler = function(response) {
-		$form.append($('<input type="hidden" name="conekta_token" />').val(response.id));
-		$form.submit();
-	};
+  $("body").on("click", "form.checkout input:submit", function () {
+    $(
+      ".woocommerce_error, .woocommerce-error, .woocommerce-message, .woocommerce_message"
+    ).remove();
+    $("form.checkout").find('[name="conekta_token"]').remove();
+  });
 
-	$('body').on('click', 'form#order_review input:submit', function(){
-		if($('input[name=payment_method]:checked').val() != 'conektacard'){
-			return true;
-		}
+  $("form.checkout").bind("checkout_place_order_conektacard", function (e) {
+    e.preventDefault();
 
-		return false;
-	});
+    var $paymentErrors = $form.find('.payment_method_conektacard .payment-errors');
+    var showError = function (message) {
+      $paymentErrors.text(message);
+      $form.unblock();
+    }
 
-	$('body').on('click', 'form.checkout input:submit', function(){
-		$('.woocommerce_error, .woocommerce-error, .woocommerce-message, .woocommerce_message').remove();
-		$('form.checkout').find('[name="conekta_token"]').remove();
-	});
+    $form.find(".payment-errors").html("");
+    $form.block({
+      message: null,
+      overlayCSS: {
+        background: "#fff url(" +
+          woocommerce_params.ajax_loader_url + ") no-repeat center",
+        backgroundSize: "16px 16px",
+        opacity: 0.6
+      }
+    });
 
-	$('form.checkout').bind('checkout_place_order_conektacard', function (e) {
-		$form.find('.payment-errors').html('');
-		$form.block({message: null, overlayCSS: {background: "#fff url(" + woocommerce_params.ajax_loader_url + ") no-repeat center", backgroundSize: "16px 16px", opacity: 0.6}});
+    if ($form.find('[name="conekta_token"]').length) {
+      return true;
+    }
+    var onBuy = function (token) {
+      if (token.id) {
+        node = document.createElement("input");
+        node.type = "hidden";
+        node.name = "conekta_token";
+        node.value = token.id;
+        $form.append(node);
+        $form.submit();
+      } else {
+        if (!token.card) {
+          return showError('El número de tarjeta es inválido');
+        } else if (!token.cvc) {
+          return showError('El cvc es inválido');
+        } else if (!token.date) {
+          return showError('La fecha de la tarjeta es inválida');
+        }
+      }
+    };
 
-		if ($form.find('[name="conekta_token"]').length){
-			return true;
-		}
+    cardHolderName = document.getElementById('conekta-card-name').value;
+    expirationMonth = document.getElementById('card_expiration').value;
+    expirationYear = document.getElementById('card_expiration_yr').value;
 
-		Conekta.token.create($form, conektaSuccessResponseHandler, conektaErrorResponseHandler);
+    checkout.tokenize({
+      name: cardHolderName,
+      expYear: expirationYear,
+      expMonth: expirationMonth
+    }, onBuy);
 
-		return false;
-	}); 
+    return false;
+  });
+
+  $(document.body).on("updated_checkout wc-credit-card-form-init", function () {
+    var tokenComponent = {
+      'box-shadow': 'inset 2px 0 0 #0f834d;',
+      'padding': '.6180469716em;',
+      'background-color': '#f2f2f2;',
+      'color': '#43454b;',
+      'outline': '0;',
+      'border': '0;',
+      '-webkit-appearance': 'none;',
+      'box-sizing': 'border-box;',
+      'font-weight': '400;',
+      'height': '45.65px',
+      'width': '100%;',
+      'font-size': '100%;',
+      'margin': '0;',
+      'vertical-align': 'baseline;',
+      'font-family': '"Source Sans Pro",HelveticaNeue-Light,"Helvetica Neue Light","Helvetica Neue",Helvetica,Arial,"Lucida Grande",sans-serif;',
+      'line-height': '1.618;',
+      'text-rendering': 'optimizeLegibility;',
+      'list-style': 'none !important;',
+      'word-wrap': 'break-word;'
+    };
+
+    var cardComponent = {
+      style: tokenComponent,
+      advanceStyle: [{
+        name: "valid",
+        style: {
+          "box-shadow": "inset 2px 0 0 #0f834d",
+        }
+      }],
+      animation: true,
+      elementID: "conekta-card-number"
+    };
+
+    var cvcComponent = {
+      style: tokenComponent,
+      advanceStyle: [{
+        name: "valid",
+        style: {
+          "box-shadow": "inset 2px 0 0 #0f834d"
+        }
+      }],
+      elementID: "conekta-card-cvc"
+    };
+
+    checkout = new ConektaDirect(
+      wc_conekta_params.public_key,
+      cardComponent,
+      cvcComponent
+    );
+  });
 });

--- a/conekta_card_gateway.php
+++ b/conekta_card_gateway.php
@@ -19,7 +19,8 @@ class WC_Conekta_Card_Gateway extends WC_Conekta_Plugin
     protected $transaction_error_message = null;
     protected $currencies                = array('MXN', 'USD');
 
-    public function __construct() {
+    public function __construct()
+    {
         $this->id = 'conektacard';
         $this->method_title = __('Conekta Card', 'conektacard');
         $this->has_fields = true;
@@ -30,9 +31,8 @@ class WC_Conekta_Card_Gateway extends WC_Conekta_Plugin
         $this->title       = $this->settings['title'];
         $this->description = '';
         $this->icon        = $this->settings['alternate_imageurl'] ?
-                             $this->settings['alternate_imageurl'] :
-                             WP_PLUGIN_URL . "/" . plugin_basename( dirname(__FILE__))
-                             . '/images/credits.png';
+            $this->settings['alternate_imageurl'] : WP_PLUGIN_URL . "/" . plugin_basename(dirname(__FILE__))
+            . '/images/credits.png';
 
         $this->use_sandbox_api      = strcmp($this->settings['debug'], 'yes') == 0;
         $this->enable_meses         = strcmp($this->settings['meses'], 'yes') == 0;
@@ -41,18 +41,15 @@ class WC_Conekta_Card_Gateway extends WC_Conekta_Plugin
         $this->test_publishable_key = $this->settings['test_publishable_key'];
         $this->live_publishable_key = $this->settings['live_publishable_key'];
         $this->publishable_key      = $this->use_sandbox_api ?
-                                      $this->test_publishable_key :
-                                      $this->live_publishable_key;
+            $this->test_publishable_key : $this->live_publishable_key;
         $this->secret_key           = $this->use_sandbox_api ?
-                                      $this->test_api_key :
-                                      $this->live_api_key;
-        $this->lang_options         = parent::ckpg_set_locale_options()->
-                                    ckpg_get_lang_options();
+            $this->test_api_key : $this->live_api_key;
+        $this->lang_options         = parent::ckpg_set_locale_options()->ckpg_get_lang_options();
 
         add_action('wp_enqueue_scripts', array($this, 'ckpg_payment_fields'));
         add_action(
-          'woocommerce_update_options_payment_gateways_'.$this->id,
-          array($this, 'process_admin_options')
+            'woocommerce_update_options_payment_gateways_' . $this->id,
+            array($this, 'process_admin_options')
         );
         add_action('admin_notices', array(&$this, 'ckpg_perform_ssl_check'));
 
@@ -60,8 +57,8 @@ class WC_Conekta_Card_Gateway extends WC_Conekta_Plugin
             $this->enabled = false;
         }
 
-        if(empty($this->secret_key)) {
-          $this->enabled = false;
+        if (empty($this->secret_key)) {
+            $this->enabled = false;
         }
     }
 
@@ -71,93 +68,99 @@ class WC_Conekta_Card_Gateway extends WC_Conekta_Plugin
     */
     public function ckpg_perform_ssl_check()
     {
-        if (!$this->use_sandbox_api
-          && get_option('woocommerce_force_ssl_checkout') == 'no'
-          && $this->enabled == 'yes') {
+        if (
+            !$this->use_sandbox_api
+            && get_option('woocommerce_force_ssl_checkout') == 'no'
+            && $this->enabled == 'yes'
+        ) {
             echo '<div class="error"><p>'
-              .sprintf(
-                __('%s sandbox testing is disabled and can performe live transactions'
-                .' but the <a href="%s">force SSL option</a> is disabled; your checkout'
-                .' is not secure! Please enable SSL and ensure your server has a valid SSL'
-                .' certificate.', 'woothemes'),
-                $this->GATEWAY_NAME, admin_url('admin.php?page=settings')
-              )
-            .'</p></div>';
+                . sprintf(
+                    __('%s sandbox testing is disabled and can performe live transactions'
+                        . ' but the <a href="%s">force SSL option</a> is disabled; your checkout'
+                        . ' is not secure! Please enable SSL and ensure your server has a valid SSL'
+                        . ' certificate.', 'woothemes'),
+                    $this->GATEWAY_NAME,
+                    admin_url('admin.php?page=settings')
+                )
+                . '</p></div>';
         }
     }
 
     public function ckpg_init_form_fields()
     {
         $this->form_fields = array(
-         'enabled' => array(
-          'type'        => 'checkbox',
-          'title'       => __('Enable/Disable', 'woothemes'),
-          'label'       => __('Enable Credit Card Payment', 'woothemes'),
-          'default'     => 'yes'
-          ),
-         'meses' => array(
-            'type'        => 'checkbox',
-            'title'       => __('Meses sin Intereses', 'woothemes'),
-            'label'       => __('Enable Meses sin Intereses', 'woothemes'),
-            'default'     => 'no'
+            'enabled' => array(
+                'type'        => 'checkbox',
+                'title'       => __('Enable/Disable', 'woothemes'),
+                'label'       => __('Enable Credit Card Payment', 'woothemes'),
+                'default'     => 'yes'
             ),
-         'debug' => array(
-            'type'        => 'checkbox',
-            'title'       => __('Testing', 'woothemes'),
-            'label'       => __('Turn on testing', 'woothemes'),
-            'default'     => 'no'
+            'meses' => array(
+                'type'        => 'checkbox',
+                'title'       => __('Meses sin Intereses', 'woothemes'),
+                'label'       => __('Enable Meses sin Intereses', 'woothemes'),
+                'default'     => 'no'
             ),
-         'title' => array(
-            'type'        => 'text',
-            'title'       => __('Title', 'woothemes'),
-            'description' => __('This controls the title which the user sees during checkout.', 'woothemes'),
-            'default'     => __('Credit Card Payment', 'woothemes')
+            'debug' => array(
+                'type'        => 'checkbox',
+                'title'       => __('Testing', 'woothemes'),
+                'label'       => __('Turn on testing', 'woothemes'),
+                'default'     => 'no'
             ),
-         'test_api_key' => array(
-             'type'        => 'password',
-             'title'       => __('Conekta API Test Private key', 'woothemes'),
-             'default'     => __('', 'woothemes')
-             ),
-         'test_publishable_key' => array(
-             'type'        => 'text',
-             'title'       => __('Conekta API Test Public key', 'woothemes'),
-             'default'     => __('', 'woothemes')
-             ),
-         'live_api_key' => array(
-             'type'        => 'password',
-             'title'       => __('Conekta API Live Private key', 'woothemes'),
-             'default'     => __('', 'woothemes')
-             ),
-         'live_publishable_key' => array(
-             'type'        => 'text',
-             'title'       => __('Conekta API Live Public key', 'woothemes'),
-             'default'     => __('', 'woothemes')
-             ),
-         'alternate_imageurl' => array(
-           'type'        => 'text',
-           'title'       => __('Alternate Image to display on checkout, use fullly qualified url, served via https', 'woothemes'),
-           'default'     => __('', 'woothemes')
-           ),
+            'title' => array(
+                'type'        => 'text',
+                'title'       => __('Title', 'woothemes'),
+                'description' => __('This controls the title which the user sees during checkout.', 'woothemes'),
+                'default'     => __('Credit Card Payment', 'woothemes')
+            ),
+            'test_api_key' => array(
+                'type'        => 'password',
+                'title'       => __('Conekta API Test Private key', 'woothemes'),
+                'default'     => __('', 'woothemes')
+            ),
+            'test_publishable_key' => array(
+                'type'        => 'text',
+                'title'       => __('Conekta API Test Public key', 'woothemes'),
+                'default'     => __('', 'woothemes')
+            ),
+            'live_api_key' => array(
+                'type'        => 'password',
+                'title'       => __('Conekta API Live Private key', 'woothemes'),
+                'default'     => __('', 'woothemes')
+            ),
+            'live_publishable_key' => array(
+                'type'        => 'text',
+                'title'       => __('Conekta API Live Public key', 'woothemes'),
+                'default'     => __('', 'woothemes')
+            ),
+            'alternate_imageurl' => array(
+                'type'        => 'text',
+                'title'       => __('Alternate Image to display on checkout, use fullly qualified url, served via https', 'woothemes'),
+                'default'     => __('', 'woothemes')
+            ),
 
 
-         );
+        );
     }
 
-    public function admin_options() {
+    public function admin_options()
+    {
         include_once('templates/admin.php');
     }
 
-    public function payment_fields() {
+    public function payment_fields()
+    {
         include_once('templates/payment.php');
     }
 
-    public function ckpg_payment_fields() {
+    public function ckpg_payment_fields()
+    {
         if (!is_checkout()) {
             return;
         }
 
-        wp_enqueue_script('conekta_js', 'https://conektaapi.s3.amazonaws.com/v0.3.2/js/conekta.js', '', '', true);
-        wp_enqueue_script('tokenize', WP_PLUGIN_URL."/".plugin_basename(dirname(__FILE__)).'/assets/js/tokenize.js', '', '1.0', true); //check import convention
+        wp_enqueue_script('conekta_js', 'https://s3.us-east-2.amazonaws.com/conektadirect/latest/index.js', '', '', true);
+        wp_enqueue_script('tokenize', WP_PLUGIN_URL . "/" . plugin_basename(dirname(__FILE__)) . '/assets/js/tokenize.js', '', '1.0', true); //check import convention
 
         //PCI
         $params = array(
@@ -239,16 +242,15 @@ class WC_Conekta_Card_Gateway extends WC_Conekta_Plugin
 
             $this->transaction_id = $charge->id;
             if ($data['monthly_installments'] > 1) {
-                update_post_meta( $this->order->get_id(), 'meses-sin-intereses', $data['monthly_installments']);
+                update_post_meta($this->order->get_id(), 'meses-sin-intereses', $data['monthly_installments']);
             }
-            update_post_meta( $this->order->get_id(), 'transaction_id', $this->transaction_id);
+            update_post_meta($this->order->get_id(), 'transaction_id', $this->transaction_id);
             return true;
-
-        } catch(\Conekta\Handler $e) {
+        } catch (\Conekta\Handler $e) {
             $description = $e->getMessage();
             global $wp_version;
             if (version_compare($wp_version, '4.1', '>=')) {
-                wc_add_notice(__('Error: ', 'woothemes') . $description , $notice_type = 'error');
+                wc_add_notice(__('Error: ', 'woothemes') . $description, $notice_type = 'error');
             } else {
                 error_log('Gateway Error:' . $description . "\n");
                 $woocommerce->add_error(__('Error: ', 'woothemes') . $description);
@@ -260,12 +262,12 @@ class WC_Conekta_Card_Gateway extends WC_Conekta_Plugin
     protected function ckpg_mark_as_failed_payment()
     {
         $this->order->add_order_note(
-         sprintf(
-             "%s Credit Card Payment Failed : '%s'",
-             $this->GATEWAY_NAME,
-             $this->transaction_error_message
-             )
-         );
+            sprintf(
+                "%s Credit Card Payment Failed : '%s'",
+                $this->GATEWAY_NAME,
+                $this->transaction_error_message
+            )
+        );
     }
 
     protected function ckpg_completeOrder()
@@ -275,17 +277,17 @@ class WC_Conekta_Card_Gateway extends WC_Conekta_Plugin
         if ($this->order->get_status() == 'completed')
             return;
 
-            // adjust stock levels and change order status
+        // adjust stock levels and change order status
         $this->order->payment_complete();
         $woocommerce->cart->empty_cart();
 
         $this->order->add_order_note(
-           sprintf(
-               "%s payment completed with Transaction Id of '%s'",
-               $this->GATEWAY_NAME,
-               $this->transaction_id
-               )
-           );
+            sprintf(
+                "%s payment completed with Transaction Id of '%s'",
+                $this->GATEWAY_NAME,
+                $this->transaction_id
+            )
+        );
 
         unset($_SESSION['order_awaiting_payment']);
     }
@@ -294,18 +296,15 @@ class WC_Conekta_Card_Gateway extends WC_Conekta_Plugin
     {
         global $woocommerce;
         $this->order        = new WC_Order($order_id);
-        if ($this->ckpg_send_to_conekta())
-        {
+        if ($this->ckpg_send_to_conekta()) {
             $this->ckpg_completeOrder();
 
             $result = array(
                 'result' => 'success',
                 'redirect' => $this->get_return_url($this->order)
-                );
+            );
             return $result;
-        }
-        else
-        {
+        } else {
             $this->ckpg_mark_as_failed_payment();
             WC()->session->reload_checkout = true;
         }
@@ -317,16 +316,19 @@ class WC_Conekta_Card_Gateway extends WC_Conekta_Plugin
      * @access public
      * @return bool
      */
-    public function ckpg_validate_currency() {
+    public function ckpg_validate_currency()
+    {
         return in_array(get_woocommerce_currency(), $this->currencies);
     }
 
-    public function ckpg_is_null_or_empty_string($string) {
+    public function ckpg_is_null_or_empty_string($string)
+    {
         return (!isset($string) || trim($string) === '');
     }
 }
 
-function ckpg_conekta_card_add_gateway($methods) {
+function ckpg_conekta_card_add_gateway($methods)
+{
     array_push($methods, 'WC_Conekta_Card_Gateway');
     return $methods;
 }

--- a/templates/payment.php
+++ b/templates/payment.php
@@ -1,5 +1,5 @@
 <?php
-/*
+ /*
  * Title   : Conekta Payment extension for WooCommerce
  * Author  : Cristina Randall
  * Url     : https://www.conekta.io/es/docs/plugins/woocommerce
@@ -8,13 +8,13 @@
 <div class="clear"></div>
 <span style="width: 100%; float: left; color: red;" class='payment-errors required'></span>
 <div class="form-row form-row-wide">
-  <label for="conekta-card-number"><?php echo esc_html($this->lang_options["card_number"]); ?><span class="required">*</span></label>
-  <input id="conekta-card-number" class="input-text" type="text" data-conekta="card[number]" />
+    <label for="conekta-card-number"><?php echo esc_html($this->lang_options["card_number"]); ?><span class="required">*</span></label>
+    <div id="conekta-card-number" style="height: 68px;"></div>
 </div>
 
 <div class="form-row form-row-wide">
-  <label for="conekta-card-name"> <?php echo esc_html($this->lang_options["card_name"]); ?><span class="required">*</span></label>
-  <input id="conekta-card-name" type="text" data-conekta="card[name]" class="input-text" />
+    <label for="conekta-card-name"> <?php echo esc_html($this->lang_options["card_name"]); ?><span class="required">*</span></label>
+    <input id="conekta-card-name" type="text" data-conekta="card[name]" class="input-text" />
 </div>
 
 <div class="clear"></div>
@@ -22,47 +22,43 @@
 <p class="form-row form-row-first">
     <label for="card_expiration"><?php echo esc_html($this->lang_options["month_options"]) ?> <span class="required">*</span></label>
     <select id="card_expiration" data-conekta="card[exp_month]" class="month" autocomplete="off">
-             <option selected="selected" value=""><?php echo esc_html($this->lang_options["month"]) ?></option>
-             <?php foreach($this->lang_options["card_expiration"] as $month => $description): ?>
-              <option value="<?php echo esc_html($month); ?>"><?php echo esc_html($description); ?></option>
-             <?php endforeach; ?>
+        <option selected="selected" value=""><?php echo esc_html($this->lang_options["month"]) ?></option>
+        <?php foreach ($this->lang_options["card_expiration"] as $month => $description) : ?>
+        <option value="<?php echo esc_html($month); ?>"><?php echo esc_html($description); ?></option>
+        <?php endforeach; ?>
     </select>
 </p>
 <p class="form-row form-row-last">
     <label><?php echo esc_html($this->lang_options["year_options"]) ?><span class="required">*</span></label>
     <select id="card_expiration_yr" data-conekta="card[exp_year]" class="year" autocomplete="off">
-              <option selected="selected" value=""> <?php echo esc_html($this->lang_options["year"]) ?></option>
-              <?php
-              $start_year = (integer) date("Y");
-              $end_year = (integer) date("Y", strtotime("+10 years"));
-              for($i = $start_year; $i <= $end_year; $i++): ?>
-                <option value="<?php echo $i; ?>"><?php echo $i; ?></option>
-              <?php endfor; ?>
+        <option selected="selected" value=""> <?php echo esc_html($this->lang_options["year"]) ?></option>
+        <?php
+        $start_year = (integer)date("Y");
+        $end_year = (integer)date("Y", strtotime("+10 years"));
+        for ($i = $start_year; $i <= $end_year; $i++) : ?>
+        <option value="<?php echo $i; ?>"><?php echo $i; ?></option>
+        <?php endfor; ?>
     </select>
 </p>
 
-<!--<div class="form-row form-row-wide">
-  <label for="conekta-card-expiration"><?php echo esc_html($this->lang_options["card_expiration"]); ?> (MM/YY) <span class="required">*</span></label>
-  <input id="conekta-card-expiration" data-conekta="card[expiration]" class="input-text" type="text" autocomplete="off" placeholder="MM / YY" />
-</div>-->
-
+<?php echo esc_html($this->lang_options["card_expiration"]); ?>
 <div class="clear"></div>
 
 <p class="form-row form-row-first">
     <label for="conekta-card-cvc">CVC <span class="required">*</span></label>
-    <input id="conekta-card-cvc" class="input-text" type="text" maxlength="4" data-conekta="card[cvc]" value=""  style="border-radius:6px"/>
+    <div id="conekta-card-cvc" style="height: 68px;"></div>
 </p>
 
-<?php if ($this->enable_meses): ?>
+<?php if ($this->enable_meses) : ?>
 <p class="form-row form-row-last">
-  <label><?php echo esc_html($this->lang_options["payment_type"]) ?><span class="required">*</span></label>
-  <select id="monthly_installments" name="monthly_installments" autocomplete="off">
-    <option selected="selected" value="1"><?php echo esc_html($this->lang_options["single_payment"]) ?></option>
-    <?php foreach($this->lang_options["monthly_installments"] AS $months => $description): ?>
-      <option value="<?php echo esc_html($months); ?>"><?php echo esc_html($description); ?></option>
-    <?php endforeach; ?>
-  </select>
+    <label><?php echo esc_html($this->lang_options["payment_type"]) ?><span class="required">*</span></label>
+    <select id="monthly_installments" name="monthly_installments" autocomplete="off">
+        <option selected="selected" value="1"><?php echo esc_html($this->lang_options["single_payment"]) ?></option>
+        <?php foreach ($this->lang_options["monthly_installments"] as $months => $description) : ?>
+        <option value="<?php echo esc_html($months); ?>"><?php echo esc_html($description); ?></option>
+        <?php endforeach; ?>
+    </select>
 </p>
 
 <?php endif; ?>
-<div class="clear"></div>
+<div class="clear"></div> 


### PR DESCRIPTION

![Captura de pantalla 2019-03-27 a la(s) 10 36 14](https://user-images.githubusercontent.com/10160626/55094688-77f19a80-507c-11e9-91c0-f13274c47da8.png)
![Captura de pantalla 2019-03-27 a la(s) 10 37 38](https://user-images.githubusercontent.com/10160626/55094689-788a3100-507c-11e9-927d-c91db3257c17.png)
![Captura de pantalla 2019-03-27 a la(s) 10 37 50](https://user-images.githubusercontent.com/10160626/55094690-788a3100-507c-11e9-8f17-79ea7bdd52e9.png)


1. Why is this change neccesary?
Because we needed our iFrame to look identical to WooCommerce form.

2. How does it address the issue?
The styles were added.

3. What side effects does this change have?
It looks cute.