### PR TITLE
feature: Add a checkbox to select if the iframe will be used.

### DIFF
--- a/assets/js/tokenize.js
+++ b/assets/js/tokenize.js
@@ -5,7 +5,7 @@ jQuery(document).ready(function ($) {
   var showError = function (message) {
     $paymentErrors.text(message);
     $form.unblock();
-  }
+  };
 
   $paymentErrors.html('');
 
@@ -30,7 +30,7 @@ jQuery(document).ready(function ($) {
     var showError = function (message) {
       $paymentErrors.text(message);
       $form.unblock();
-    }
+    };
 
     $form.find(".payment-errors").html("");
     $form.block({

--- a/conekta_card_gateway.php
+++ b/conekta_card_gateway.php
@@ -36,6 +36,7 @@ class WC_Conekta_Card_Gateway extends WC_Conekta_Plugin
 
         $this->use_sandbox_api      = strcmp($this->settings['debug'], 'yes') == 0;
         $this->enable_meses         = strcmp($this->settings['meses'], 'yes') == 0;
+        $this->enable_iframe         = strcmp($this->settings['iframe'], 'yes') == 0;
         $this->test_api_key         = $this->settings['test_api_key'];
         $this->live_api_key         = $this->settings['live_api_key'];
         $this->test_publishable_key = $this->settings['test_publishable_key'];
@@ -107,6 +108,12 @@ class WC_Conekta_Card_Gateway extends WC_Conekta_Plugin
                 'label'       => __('Turn on testing', 'woothemes'),
                 'default'     => 'no'
             ),
+            'iframe' => array(
+                'type'        => 'checkbox',
+                'title'       => __('Iframe', 'woothemes'),
+                'label'       => __('Enable iframe (beta)', 'woothemes'),
+                'default'     => 'no'
+            ),
             'title' => array(
                 'type'        => 'text',
                 'title'       => __('Title', 'woothemes'),
@@ -150,7 +157,11 @@ class WC_Conekta_Card_Gateway extends WC_Conekta_Plugin
 
     public function payment_fields()
     {
-        include_once('templates/payment.php');
+        if ($this->enable_iframe) {
+            include_once('templates/payment.php');
+        } else {
+            include_once('templates/payment_legacy.php');
+        }
     }
 
     public function ckpg_payment_fields()

--- a/templates/payment_legacy.php
+++ b/templates/payment_legacy.php
@@ -5,12 +5,11 @@
  * Url     : https://www.conekta.io/es/docs/plugins/woocommerce
  */
 ?>
-
 <div class="clear"></div>
 <span style="width: 100%; float: left; color: red;" class='payment-errors required'></span>
 <div class="form-row form-row-wide">
     <label for="conekta-card-number"><?php echo esc_html($this->lang_options["card_number"]); ?><span class="required">*</span></label>
-    <div id="conekta-card-number" style="height: 68px;"></div>
+    <input id="conekta-card-number" class="input-text" type="text" data-conekta="card[number]" />
 </div>
 
 <div class="form-row form-row-wide">
@@ -34,20 +33,21 @@
     <select id="card_expiration_yr" data-conekta="card[exp_year]" class="year" autocomplete="off">
         <option selected="selected" value=""> <?php echo esc_html($this->lang_options["year"]) ?></option>
         <?php
-        $start_year = (integer)date("Y");
-        $end_year = (integer)date("Y", strtotime("+10 years"));
-        for ($i = $start_year; $i <= $end_year; $i++) : ?>
+         $start_year = (integer)date("Y");
+         $end_year = (integer)date("Y", strtotime("+10 years"));
+         for ($i = $start_year; $i <= $end_year; $i++) : ?>
         <option value="<?php echo $i; ?>"><?php echo $i; ?></option>
         <?php endfor; ?>
     </select>
 </p>
 
 <?php echo esc_html($this->lang_options["card_expiration"]); ?>
+
 <div class="clear"></div>
 
 <p class="form-row form-row-first">
     <label for="conekta-card-cvc">CVC <span class="required">*</span></label>
-    <div id="conekta-card-cvc" style="height: 68px;"></div>
+    <input id="conekta-card-cvc" class="input-text" type="text" maxlength="4" data-conekta="card[cvc]" value="" style="border-radius:6px" />
 </p>
 
 <?php if ($this->enable_meses) : ?>


### PR DESCRIPTION
1. Why is this change neccesary?
Because we needed a way to let our merchants decide if the iframe will be used
so they can test it or revert to the previous working version if they find any problems.

2. How does it address the issue?
By adding a checkbox in Conekta's payment plugin configuration.

3. What side effects does this change have?
None.

![Captura de pantalla 2019-03-27 a la(s) 17 05 59](https://user-images.githubusercontent.com/10160626/55118074-ad18df80-50b2-11e9-8a1b-c3f2c2decaba.png)
