### PR TITLE
Fix of amount format in orders.

### DIFF
--- a/conekta_card_gateway.php
+++ b/conekta_card_gateway.php
@@ -181,7 +181,7 @@ class WC_Conekta_Card_Gateway extends WC_Conekta_Plugin
 
         //ALL $data VAR ASSIGNATION IS FREE OF VALIDATION
         $data             = ckpg_get_request_data($this->order);
-        $amount           = $data['amount'];
+        $amount           = (int) $data['amount'];
         $items            = $this->order->get_items();
         $taxes            = $this->order->get_taxes();
         $line_items       = ckpg_build_line_items($items, parent::ckpg_get_version());

--- a/conekta_cash_gateway.php
+++ b/conekta_cash_gateway.php
@@ -219,7 +219,7 @@ class WC_Conekta_Cash_Gateway extends WC_Conekta_Plugin
         \Conekta\Conekta::setLocale('es');
 
         $data             = ckpg_get_request_data($this->order);
-        $amount           = $data['amount'];
+        $amount           = (int) $data['amount'];
         $items            = $this->order->get_items();
         $taxes            = $this->order->get_taxes();
         $line_items       = ckpg_build_line_items($items, parent::ckpg_get_version());

--- a/conekta_spei_gateway.php
+++ b/conekta_spei_gateway.php
@@ -212,7 +212,7 @@ class WC_Conekta_Spei_Gateway extends WC_Conekta_Plugin
         \Conekta\Conekta::setLocale('es');
 
         $data             = ckpg_get_request_data($this->order);
-        $amount           = $data['amount'];
+        $amount           = (int) $data['amount'];
         $items            = $this->order->get_items();
         $taxes            = $this->order->get_taxes();
         $line_items       = ckpg_build_line_items($items, parent::ckpg_get_version());


### PR DESCRIPTION
Why is this change necessary?
Because the amount contained a float value instead of an integer

What is the impact?
High

What kind of change is this?
Simple