### PR TITLE
Use "pending" instead of "on hold" WooCommerce status

### DIFF
--- a/conekta_cash_gateway.php
+++ b/conekta_cash_gateway.php
@@ -87,7 +87,7 @@ class WC_Conekta_Cash_Gateway extends WC_Conekta_Plugin
                 $order->payment_complete();
                 $order->add_order_note(sprintf("Payment completed in Oxxo and notification of payment received"));
 
-                parent::ckpg_offline_payment_notification($order_id, $conekta_order['customer_info']['name']);
+                // Se elimina el envio personalizado de email a favor del envio nativo de woocommerce cuando se completa un pedido
             }
     }
 
@@ -192,7 +192,7 @@ class WC_Conekta_Cash_Gateway extends WC_Conekta_Plugin
     public function ckpg_email_instructions( $order, $sent_to_admin = false, $plain_text = false ) {
         if (get_post_meta( $order->get_id(), '_payment_method', true ) === $this->id){
             $instructions = $this->form_fields['instructions'];
-            if ( $instructions && 'on-hold' === $order->get_status() ) {
+            if ( $instructions && 'pending' === $order->get_status() ) {
                 echo wpautop( wptexturize( $instructions['default'] ) ) . PHP_EOL;
             }
         }
@@ -297,8 +297,11 @@ class WC_Conekta_Cash_Gateway extends WC_Conekta_Plugin
         $this->order        = new WC_Order($order_id);
         if ($this->ckpg_send_to_conekta())
             {
-                // Mark as on-hold (we're awaiting the notification of payment)
+                // Mark as pending (we're awaiting the notification of payment)
                 $this->order->update_status('on-hold', __( 'Awaiting the conekta OXXO payment', 'woocommerce' ));
+
+                // Send order email to customer
+                parent::ckpg_order_notification($order_id, $this->order->billing_first_name.' '.$this->order->billing_last_name);
 
                 // Remove cart
                 $woocommerce->cart->empty_cart();

--- a/conekta_plugin.php
+++ b/conekta_plugin.php
@@ -73,6 +73,28 @@ class WC_Conekta_Plugin extends WC_Payment_Gateway
         sprintf(__('Pago realizado satisfactoriamente')), $body_message);
      	  $mail_admin->send(get_option("admin_email"), $title, $message);
      	  unset($mail_admin);
+	}
+	
+
+	// Order email notification
+	public function ckpg_order_notification($order_id, $customer)
+	{
+   		global $woocommerce;
+   		$order = new WC_Order($order_id);
+
+   		$title = sprintf("Pedido #%s - Pendiente de pago", $order->get_order_number());
+   		$body_message = "<p style=\"margin:0 0 16px\">Pedido #".$order->get_order_number()." - Pendiente de pago:</p><br />" . $this->ckpg_assemble_email_payment($order);
+
+      	// Email for customer
+      	$customer = esc_html($customer);
+      	$customer = sanitize_text_field($customer);
+
+      	$mail_customer = $woocommerce->mailer();
+      	$message = $mail_customer->wrap_message(
+        sprintf(__('Hola, %s'), $customer), $body_message);
+     	  $mail_customer->send($order->get_billing_email(), $title, $message);
+     	  unset($mail_customer);
+     	  
     }
 
     public function ckpg_assemble_email_payment($order){


### PR DESCRIPTION
Use WooCommerce  "pending" status instead of "on hold" for new created orders vía cash or spei payment. Also triggers new email with payment info.