### PR TITLE
Fix to shipping "amount" parsing

### DIFF
--- a/conekta_gateway_helper.php
+++ b/conekta_gateway_helper.php
@@ -211,7 +211,7 @@ function ckpg_get_request_data($order)
         if (!empty($shipping_method)) {
             $shipping_lines  = array(
                 array(
-                    'amount'  => (int) intval($amountShipping),
+                    'amount'  => (int) $amountShipping,
                     'carrier' => $shipping_method,
                     'method'  => $shipping_method
                 )

--- a/conekta_gateway_helper.php
+++ b/conekta_gateway_helper.php
@@ -211,7 +211,7 @@ function ckpg_get_request_data($order)
         if (!empty($shipping_method)) {
             $shipping_lines  = array(
                 array(
-                    'amount'  => (int) number_format($amountShipping),
+                    'amount'  => (int) intval($amountShipping),
                     'carrier' => $shipping_method,
                     'method'  => $shipping_method
                 )


### PR DESCRIPTION
The wooCommerce plugin was updated to v3.0.6 and has a bug that parses the shipping amount incorrectly making the tax adjustment negative thorwing an error at processing. The error is caused by the following sintax:
(int) number_format(9900.00);
=> 9
(int) 9900.00;
=> 9900